### PR TITLE
Fixes Issue #30 

### DIFF
--- a/R/speech.R
+++ b/R/speech.R
@@ -211,11 +211,13 @@ parse_op <- function(x){
     if(!is.null(x$error)){
       out <- x$error
     } else {
-      out <- parse_speech(x$response)
+      if(grepl('LongRunningRecognize', x$metadata$`@type`)){
+        out <- parse_async(x)
+      } else {
+        out <- parse_speech(x$response)
+      }
     }
-  } else {
-    out <- parse_async(x)
   }
-
   out
 }
+


### PR DESCRIPTION
Hi @MarkEdmondson1234, so I traced down the issue I was having.  `x$metadata$startTime` is indeed present, no issue there that was just my not having your utility functions loaded when I did my testing.  The source of the problem I was having was in `parse_op`.  `x$done` is present and TRUE for long running operations requiring `parse_async(x)` which caused `parse_speech(x$response)` to be called and fail to parse the long running operation.  The below is a possible fix that looks for `LongRunningRecognize` as the type.  While this works, I don't know if there might be a better solution that parses this into transcript and timings as you have for parse_speech().  I haven't worked out all of what's going on there and what is causing my longer files to fail to parse when my shorter files work fine.  Both indicate `LongRunningRecognize` and I haven't spotted the difference with an str() on the returned request without parsing, but calling `parse_async()` works for both the longer files.   

```
parse_op <- function(x){
  if(!is.null(x$done)){
      if(!is.null(x$error)){
        out <- x$error
      } else {
        if(grepl('LongRunningRecognize', x$metadata$`@type`)){
          out <- parse_async(x)
        } else {
        out <- parse_speech(x$response)
        }
      }
  }
  out
}
```