### PR TITLE
Fixing error in translate, correctly stopping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Depends: R (>= 3.3)
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 VignetteBuilder: knitr
 Imports:
     assertthat,

--- a/R/translate.R
+++ b/R/translate.R
@@ -97,11 +97,18 @@ gl_translate_detect <- function(string){
 
   me <- tryCatch(call_api(the_body = pars),
                  error = function(ex){
-                   if(grepl(catch_errors, ex$message)){
+                   if (grepl(catch_errors, ex$message)) {
                      my_message("Attempting to split into several API calls", level = 3)
                      Reduce(rbind, lapply(string, gl_translate_detect))
+                   } else if (grepl("User Rate Limit Exceeded",
+                                 ex$message)) {
+                     my_message("Characters per 100 seconds rate limit reached, waiting 10 seconds...",
+                                level = 3)
+                     Sys.sleep(10)
+                     ## try again
+                     gl_translate_detect(string)
                    } else {
-                     stop(ex$message)
+                     stop(ex$message, call. = FALSE)
                    }
                  })
 

--- a/R/translate.R
+++ b/R/translate.R
@@ -100,6 +100,8 @@ gl_translate_detect <- function(string){
                    if(grepl(catch_errors, ex$message)){
                      my_message("Attempting to split into several API calls", level = 3)
                      Reduce(rbind, lapply(string, gl_translate_detect))
+                   } else {
+                     stop(ex$message)
                    }
                  })
 

--- a/man/gl_nlp.Rd
+++ b/man/gl_nlp.Rd
@@ -6,8 +6,8 @@
 \usage{
 gl_nlp(string, nlp_type = c("annotateText", "analyzeEntities",
   "analyzeSentiment", "analyzeSyntax", "analyzeEntitySentiment",
-  "classifyText"), type = c("PLAIN_TEXT", "HTML"), language = c("en", "zh",
-  "zh-Hant", "fr", "de", "it", "ja", "ko", "pt", "es"),
+  "classifyText"), type = c("PLAIN_TEXT", "HTML"), language = c("en",
+  "zh", "zh-Hant", "fr", "de", "it", "ja", "ko", "pt", "es"),
   encodingType = c("UTF8", "UTF16", "UTF32", "NONE"))
 }
 \arguments{

--- a/man/gl_speech.Rd
+++ b/man/gl_speech.Rd
@@ -5,8 +5,9 @@
 \title{Call Google Speech API}
 \usage{
 gl_speech(audio_source, encoding = c("LINEAR16", "FLAC", "MULAW", "AMR",
-  "AMR_WB", "OGG_OPUS", "SPEEX_WITH_HEADER_BYTE"), sampleRateHertz = NULL,
-  languageCode = "en-US", maxAlternatives = 1L, profanityFilter = FALSE,
+  "AMR_WB", "OGG_OPUS", "SPEEX_WITH_HEADER_BYTE"),
+  sampleRateHertz = NULL, languageCode = "en-US",
+  maxAlternatives = 1L, profanityFilter = FALSE,
   speechContexts = NULL, asynch = FALSE, customConfig = NULL)
 }
 \arguments{

--- a/man/gl_talk.Rd
+++ b/man/gl_talk.Rd
@@ -5,9 +5,10 @@
 \title{Perform text to speech}
 \usage{
 gl_talk(input, output = "output.wav", languageCode = "en",
-  gender = c("SSML_VOICE_GENDER_UNSPECIFIED", "MALE", "FEMALE", "NEUTRAL"),
-  name = NULL, audioEncoding = c("LINEAR16", "MP3", "OGG_OPUS"),
-  speakingRate = 1, pitch = 0, volumeGainDb = 0, sampleRateHertz = NULL)
+  gender = c("SSML_VOICE_GENDER_UNSPECIFIED", "MALE", "FEMALE",
+  "NEUTRAL"), name = NULL, audioEncoding = c("LINEAR16", "MP3",
+  "OGG_OPUS"), speakingRate = 1, pitch = 0, volumeGainDb = 0,
+  sampleRateHertz = NULL)
 }
 \arguments{
 \item{input}{The text to turn into speech}

--- a/man/gl_translate.Rd
+++ b/man/gl_translate.Rd
@@ -72,3 +72,4 @@ read_html(my_url) \%>\%
 Other translations: \code{\link{gl_translate_detect}},
   \code{\link{gl_translate_languages}}
 }
+\concept{translations}

--- a/man/gl_translate_detect.Rd
+++ b/man/gl_translate_detect.Rd
@@ -41,3 +41,4 @@ gl_translate_detect("katten sidder på måtten")
 Other translations: \code{\link{gl_translate_languages}},
   \code{\link{gl_translate}}
 }
+\concept{translations}

--- a/man/gl_translate_languages.Rd
+++ b/man/gl_translate_languages.Rd
@@ -37,3 +37,4 @@ gl_translate_languages("da")
 Other translations: \code{\link{gl_translate_detect}},
   \code{\link{gl_translate}}
 }
+\concept{translations}


### PR DESCRIPTION
Should fix #52.  This error catch will display the correct error, not the `nrow` false error.