### PR TITLE
Fix missing space in gl_talk call to my_message for cleaner log output

### DIFF
--- a/R/text-to-speech.R
+++ b/R/text-to-speech.R
@@ -106,7 +106,7 @@ gl_talk <- function(input,
 
   body <- rmNullObs(body)
 
-  my_message("Calling text-to-speech API:", input, level = 3)
+  my_message("Calling text-to-speech API: ", input, level = 3)
 
   call_api <- gar_api_generator("https://texttospeech.googleapis.com/v1beta1/text:synthesize",
                                 "POST",


### PR DESCRIPTION
I realize this is almost entirely pedantic, but there is a missing space in the call to my_message when running gl_talk, which makes the console log a bit less readable. For instance:

```R
> gl_talk("This is my audio player") %>% gl_talk_player()
2019-07-15 21:05:22 -- Calling text-to-speech API:This is my audio player
```

Note the lack of space at API:This.

This PR simply fixes this trivial issue! =)