### PR TITLE
Use official docs URL in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Call 'Google Cloud' machine learning APIs for text and speech tasks
   <https://cloud.google.com/speech/> to transcribe sound files to text and 
   the 'Cloud Text-to-Speech' API <https://cloud.google.com/text-to-speech/> to turn text 
   into sound files.
-URL: http://code.markedmondson.me/googleLanguageR/, https://github.com/ropensci/googleLanguageR
+URL: https://docs.ropensci.org/googleLanguageR/, https://github.com/ropensci/googleLanguageR
 BugReports: https://github.com/ropensci/googleLanguageR/issues
 Depends: R (>= 3.3)
 License: MIT + file LICENSE


### PR DESCRIPTION
We are now [automatically generating pkgdown docs](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) for all rOpenSci packages. If you'd like you can use this as the homepage. But if you prefer to host your own, that's fine too.