### PR TITLE
Add parameter to prevent overwritting of the languageCode parameter w…

### DIFF
--- a/R/text-to-speech.R
+++ b/R/text-to-speech.R
@@ -14,6 +14,7 @@
 #' @param sampleRateHertz Sample rate for returned audio
 #' @param inputType Choose between \code{text} (the default) or SSML markup. The \code{input} text must be SSML markup if you choose \code{ssml}
 #' @param effectsProfileIds Optional. An identifier which selects 'audio effects' profiles that are applied on (post synthesized) text to speech. Effects are applied on top of each other in the order they are given
+#' @param forceLanguageCode If \code{name} is provided, this will ensure that the passed \code{languageCode} is used instead of being inferred from name. This is necessary for models that require the exact code (en-us, en-gb, ...), not just the two letters shorthand (en, es, ...)
 #'
 #' @details
 #'
@@ -65,7 +66,8 @@ gl_talk <- function(input,
                     volumeGainDb = 0,
                     sampleRateHertz = NULL,
                     inputType = c("text","ssml"),
-                    effectsProfileIds = NULL){
+                    effectsProfileIds = NULL,
+                    forceLanguageCode = FALSE){
 
   inputType     <- match.arg(inputType)
   gender        <- match.arg(gender)
@@ -79,12 +81,15 @@ gl_talk <- function(input,
     speakingRate >= 0.25,
     speakingRate <= 4.0,
     pitch >= -20.0,
-    pitch <= 20.0
+    pitch <= 20.0,
+    is.logical(forceLanguageCode)
   )
 
   if(!is.null(name)){
     assert_that(is.string(name))
-    languageCode <- substr(name, 1,2)
+    if(!forceLanguageCode){
+      languageCode <- substr(name, 1,2)
+    }
     gender <- NULL
   }
 


### PR DESCRIPTION
If \code{name} is provided, this will ensure that the passed \code{languageCode} is used instead of being inferred from name. This is necessary for models that require the exact code (en-us, en-gb, ...), not just the two letters shorthand (en, es, ...)